### PR TITLE
replace deprecated redis.setex with redis.set method

### DIFF
--- a/src/cachers/redis.js
+++ b/src/cachers/redis.js
@@ -223,7 +223,7 @@ class RedisCacher extends BaseCacher {
 
 		let p;
 		if (ttl) {
-			p = this.client.setex(this.prefix + key, ttl, data);
+			p = this.client.set(this.prefix + key, data, "EX", ttl);
 		} else {
 			p = this.client.set(this.prefix + key, data);
 		}


### PR DESCRIPTION
## :memo: Description

The change involves refactoring the cachers/redis.js file to replace the deprecated setex method with the set method for setting key-value pairs. 

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

